### PR TITLE
Changed behavior of the dynamic width

### DIFF
--- a/sticky.js
+++ b/sticky.js
@@ -31,12 +31,10 @@
 
 				initial = {
 					top: $elem.css('top'),
-					width: $elem.css('width'),
 					position: $elem.css('position'),
 					marginTop: $elem.css('margin-top'),
 				},
 
-				isPositionFixed = false,
 				isSticking = false,
 				stickyLine;
 
@@ -77,7 +75,6 @@
 			}
 
 			function stickElement() {
-				initial.offsetWidth = elem.offsetWidth;
 				isSticking = true;
 				bodyClass   && $body.addClass(bodyClass);
 				stickyClass && $elem.addClass(stickyClass);
@@ -96,7 +93,7 @@
 				stickyClass && $elem.removeClass(stickyClass);
 
 				$elem
-					.css('width',    initial.offsetWidth+'px')
+					.css('width',    '')
 					.css('top',      initial.top)
 					.css('position', initial.position)
 					.css('margin-top',   initial.marginTop);
@@ -123,7 +120,14 @@
 			scope.$on('$destroy', onDestroy);
 
 			function onResize() {
-				initial.offsetWidth = elem.offsetWidth;
+				if(isSticking){
+					var parent = window.getComputedStyle(elem.parentElement, null),
+						initialOffsetWidth = elem.parentElement.offsetWidth
+							- parent.getPropertyValue('padding-right').replace("px", "")
+							- parent.getPropertyValue('padding-left').replace("px", "");
+
+					$elem.css("width", initialOffsetWidth+"px");
+				}
 			};
 
 			function onDestroy() {


### PR DESCRIPTION
I see your point, but I'd make some adjustments yet:

At this stage we ignore all inline styles on the sticky block:

**Sticking:** 
As you said before we set the width at the moment of sticking.

**Resizing:** 
1. We handle a resize event only when our block is sticking. 
2. Your previous code considered changing of the parent block while our block is sticking so I got it back. For instance in my project, while the block is sticking, orientation of the screen might change and as a consequence width of the parent block (because its width in percents). From my point of view it's most popular case but we can make this as a configurable option.

**Unsticking:**
All that we need is just to remove our inline width. If we set width which was before being sticky we will break the initial state of the block, because as I said we ignore any inline styles.